### PR TITLE
ADLDAP 6.x/10.x Upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": "^7.1.3",
-        "adldap2/adldap2-laravel": "^5.1.2",
+        "adldap2/adldap2-laravel": "^6.0.5",
         "aws/aws-sdk-php-laravel": "^3.1",
         "comodojo/zip": "^2.1",
         "czproject/git-php": "^3.14",

--- a/composer.lock
+++ b/composer.lock
@@ -4,31 +4,35 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf6ce23914c3a148bd0c752c70e2893f",
+    "content-hash": "60e72deb0d54360955e0504a4502d21f",
     "packages": [
         {
             "name": "adldap2/adldap2",
-            "version": "v9.1.6",
+            "version": "v10.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Adldap2/Adldap2.git",
-                "reference": "d50204d3eff587957b4bb9d7382d2eda5009ed16"
+                "reference": "a6089f508b2a94cb7ff8c98ab381ff983d5f0347"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Adldap2/Adldap2/zipball/d50204d3eff587957b4bb9d7382d2eda5009ed16",
-                "reference": "d50204d3eff587957b4bb9d7382d2eda5009ed16",
+                "url": "https://api.github.com/repos/Adldap2/Adldap2/zipball/a6089f508b2a94cb7ff8c98ab381ff983d5f0347",
+                "reference": "a6089f508b2a94cb7ff8c98ab381ff983d5f0347",
                 "shasum": ""
             },
             "require": {
                 "ext-ldap": "*",
                 "illuminate/contracts": "~5.0",
                 "php": ">=7.0",
+                "psr/log": "~1.0",
                 "tightenco/collect": "~5.0"
             },
             "require-dev": {
                 "mockery/mockery": "~1.0",
                 "phpunit/phpunit": "~6.0"
+            },
+            "suggest": {
+                "ext-fileinfo": "fileinfo is required when retrieving user encoded thumbnails"
             },
             "type": "library",
             "autoload": {
@@ -57,24 +61,25 @@
                 "ldap",
                 "windows"
             ],
-            "time": "2019-04-03T19:41:38+00:00"
+            "time": "2019-05-03T21:29:12+00:00"
         },
         {
             "name": "adldap2/adldap2-laravel",
-            "version": "v5.1.3",
+            "version": "v6.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Adldap2/Adldap2-Laravel.git",
-                "reference": "1a8843b07b389ce26f6d122d19f9443224926d82"
+                "reference": "a14d5040bfec62a2e57718d3565341333e4068f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Adldap2/Adldap2-Laravel/zipball/1a8843b07b389ce26f6d122d19f9443224926d82",
-                "reference": "1a8843b07b389ce26f6d122d19f9443224926d82",
+                "url": "https://api.github.com/repos/Adldap2/Adldap2-Laravel/zipball/a14d5040bfec62a2e57718d3565341333e4068f2",
+                "reference": "a14d5040bfec62a2e57718d3565341333e4068f2",
                 "shasum": ""
             },
             "require": {
-                "adldap2/adldap2": "^9.0",
+                "adldap2/adldap2": "^10.0",
+                "illuminate/support": "~5.5.0|~5.6.0|~5.7.0|~5.8.0",
                 "php": ">=7.1"
             },
             "require-dev": {
@@ -110,7 +115,7 @@
                 "laravel",
                 "ldap"
             ],
-            "time": "2019-04-02T23:04:08+00:00"
+            "time": "2019-04-18T16:02:45+00:00"
         },
         {
             "name": "aws/aws-sdk-php",

--- a/config/ldap.php
+++ b/config/ldap.php
@@ -4,6 +4,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Logging
+    |--------------------------------------------------------------------------
+    |
+    | This option enables logging all LDAP operations on all configured
+    | connections such as bind requests and CRUD operations.
+    |
+    | Log entries will be created in your default logging stack.
+    |
+    | This option is extremely helpful for debugging connectivity issues.
+    |
+    */
+
+    'logging' => env('LDAP_LOGGING', false),
+
+    /*
+    |--------------------------------------------------------------------------
     | Connections
     |--------------------------------------------------------------------------
     |
@@ -30,7 +46,7 @@ return [
             | in your application.
             |
             | If this is set to false, you **must** connect manually before running
-            | LDAP operations.
+            | LDAP operations. Otherwise, you will receive exceptions.
             |
             */
 

--- a/config/ldap_auth.php
+++ b/config/ldap_auth.php
@@ -7,11 +7,9 @@ return [
     | Connection
     |--------------------------------------------------------------------------
     |
-    | The LDAP connection to use for laravel authentication.
+    | The LDAP connection to use for Laravel authentication.
     |
-    | You must specify connections in your `config/adldap.php` configuration file.
-    |
-    | This must be a string.
+    | You must specify connections in your `config/ldap.php` configuration file.
     |
     */
 
@@ -103,67 +101,89 @@ return [
 
     ],
 
-    'usernames' => [
+    'identifiers' => [
 
         /*
         |--------------------------------------------------------------------------
         | LDAP
         |--------------------------------------------------------------------------
         |
-        | Discover:
+        | Locate Users By:
         |
-        |   The discover value is the users attribute you would
-        |   like to locate LDAP users by in your directory.
+        |   This value is the users attribute you would like to locate LDAP
+        |   users by in your directory.
         |
         |   For example, using the default configuration below, if you're
         |   authenticating users with an email address, your LDAP server
         |   will be queried for a user with the a `userprincipalname`
         |   equal to the entered email address.
         |
-        | Authenticate:
+        | Bind Users By:
         |
-        |   The authenticate value is the users attribute you would
+        |   This value is the users attribute you would
         |   like to use to bind to your LDAP server.
         |
-        |   For example, when a user is located by the above 'discover'
-        |   attribute, the users attribute you specify below will
-        |   be used as the username to bind to your LDAP server.
+        |   For example, when a user is located by the above attribute,
+        |   the users attribute you specify below will be used as
+        |   the 'username' to bind to your LDAP server.
+        |
+        |   This is usually their distinguished name.
         |
         */
 
         'ldap' => [
 
-            'discover' => 'samaccountname',
+            'locate_users_by' => 'samaccountname',
 
-            'authenticate' => 'distinguishedname',
+            'bind_users_by' => 'distinguishedname',
 
         ],
 
-        /*
-        |--------------------------------------------------------------------------
-        | Eloquent
-        |--------------------------------------------------------------------------
-        |
-        | The value you enter is the database column name used for locating
-        | the local database record of the authenticating user.
-        |
-        | If you're using a `username` column instead, change this to `username`.
-        |
-        | This option is only applicable to the DatabaseUserProvider.
-        |
-        */
+        'database' => [
 
-        'eloquent' => 'username',
+            /*
+            |--------------------------------------------------------------------------
+            | GUID Column
+            |--------------------------------------------------------------------------
+            |
+            | The value of this option is the database column that will contain the
+            | LDAP users global identifier. This column does not need to be added
+            | to the sync attributes below. It is synchronized automatically.
+            |
+            | This option is only applicable to the DatabaseUserProvider.
+            |
+            */
+
+            'guid_column' => 'objectguid',
+
+            /*
+            |--------------------------------------------------------------------------
+            | Username Column
+            |--------------------------------------------------------------------------
+            |
+            | The value of this option is the database column that contains your
+            | users login username.
+            |
+            | This column must be added to your sync attributes below to be
+            | properly synchronized.
+            |
+            | This option is only applicable to the DatabaseUserProvider.
+            |
+            */
+
+            'username_column' => 'username',
+
+        ],
 
         /*
         |--------------------------------------------------------------------------
         | Windows Authentication Middleware (SSO)
         |--------------------------------------------------------------------------
         |
-        | Discover:
+        | Local Users By:
         |
-        |   The 'discover' value is the users attribute you would
-        |   like to locate LDAP users by in your directory.
+        |   This value is the users attribute you would like to locate LDAP
+        |   users by in your directory.
         |
         |   For example, if 'samaccountname' is the value, then your LDAP server is
         |   queried for a user with the 'samaccountname' equal to the value of
@@ -172,9 +192,9 @@ return [
         |   If a user is found, they are imported (if using the DatabaseUserProvider)
         |   into your local database, then logged in.
         |
-        | Key:
+        | Server Key:
         |
-        |    The 'key' value represents the 'key' of the $_SERVER
+        |    This value represents the 'key' of the $_SERVER
         |    array to pull the users account name from.
         |
         |    For example, $_SERVER['AUTH_USER'].
@@ -183,9 +203,9 @@ return [
 
         'windows' => [
 
-            'discover' => 'samaccountname',
+            'locate_users_by' => 'samaccountname',
 
-            'key' => 'AUTH_USER',
+            'server_key' => 'AUTH_USER',
 
         ],
 
@@ -209,8 +229,7 @@ return [
         | random 16 character hashed password upon first login, and will
         | lose access to this account upon loss of LDAP connectivity.
         |
-        | This option must be true or false and is only applicable
-        | to the DatabaseUserProvider.
+        | This option is only applicable to the DatabaseUserProvider.
         |
         */
 
@@ -239,13 +258,12 @@ return [
     | Login Fallback
     |--------------------------------------------------------------------------
     |
-    | The login fallback option allows you to login as a user located on the
+    | The login fallback option allows you to login as a user located in the
     | local database if active directory authentication fails.
     |
     | Set this to true if you would like to enable it.
     |
-    | This option must be true or false and is only
-    | applicable to the DatabaseUserProvider.
+    | This option is only applicable to the DatabaseUserProvider.
     |
     */
 
@@ -265,8 +283,7 @@ return [
     |
     | You **must** include the users login attribute here.
     |
-    | This option must be an array and is only applicable
-    | to the DatabaseUserProvider.
+    | This option is only applicable to the DatabaseUserProvider.
     |
     */
 
@@ -300,7 +317,7 @@ return [
 
     'logging' => [
 
-        'enabled' => true,
+        'enabled' => env('LDAP_LOGGING', true),
 
         'events' => [
 

--- a/database/migrations/2019_05_22_165436_add_objectguid_column.php
+++ b/database/migrations/2019_05_22_165436_add_objectguid_column.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddObjectguidColumn extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('objectguid')->unique()->nullable()->after('id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}


### PR DESCRIPTION
This upgrade adds a column for GUID to the database so a `php artisan migrate` is required along with the `composer install`.

The new ADLDAP library now tracks GUID so name changes and the like will propagate over fine. This should hopefully fix the jody issues. If it doesn't then better logging was also added.